### PR TITLE
Feature: Adding Support to benchmark various models (lora adapters, passing chat templates kwargs, etc.)

### DIFF
--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -304,9 +304,6 @@ class LLMCheck:
 
             self.extra_chat_template_kwargs = extra_chat_template_kwargs if extra_chat_template_kwargs is not None else {}
 
-            if operating_mode == "thinking":
-                self.thinking_end_token=self.tokenizer.convert_tokens_to_ids(think_end_token)
-
         self.peft_path = peft_path
 
         self.tensor_parallel_size = tensor_parallel_size
@@ -355,8 +352,12 @@ class LLMCheck:
             self.tokenizer.eos_token_id,
         ]
         converted_token = self.tokenizer.convert_tokens_to_ids("<|eot_id|>")
+
         if converted_token is not None:
             terminators.append(converted_token)
+
+        if operating_mode == "thinking":
+            self.thinking_end_token=self.tokenizer.convert_tokens_to_ids(think_end_token)
         
         self.sampling_params = SamplingParams(
             temperature=0,

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -271,7 +271,7 @@ class Inferencer():
 
 class LLMCheck:
 
-    def __init__(self, model_id, tensor_parallel_size=1, max_tokens=1, cache_dir=None, enable_prefix_caching=False, max_model_len=None):
+    def __init__(self, model_id, operating_mode="bespoke", tensor_parallel_size=1, max_tokens=1, cache_dir=None, enable_prefix_caching=False, max_model_len=None):
         from vllm import LLM, SamplingParams
 
         import logging
@@ -296,7 +296,12 @@ class LLMCheck:
             self.operating_mode="thinking"
             self.thinking_end_token=self.tokenizer.convert_tokens_to_ids("</think>")
         else:
-            raise ValueError("model_id must be 'Bespoke-MiniCheck-7B'")
+            self.model_id = model_id
+            self.operating_mode=operating_mode
+
+            if operating_model == "thinking":
+                self.thinking_end_token=self.tokenizer.convert_tokens_to_ids("</think>")
+            #raise ValueError("model_id must be 'Bespoke-MiniCheck-7B'")
 
         self.tensor_parallel_size = tensor_parallel_size
         self.max_tokens = max_tokens

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -301,7 +301,8 @@ class LLMCheck:
         else:
             self.model_id = model_id
             self.operating_mode=operating_mode
-            self.extra_chat_template_kwargs = extra_chat_template_kwargs
+
+            self.extra_chat_template_kwargs = extra_chat_template_kwargs if extra_chat_template_kwargs is not None else {}
 
             if operating_mode == "thinking":
                 self.thinking_end_token=self.tokenizer.convert_tokens_to_ids(think_end_token)

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -291,6 +291,10 @@ class LLMCheck:
         elif model_id == 'Granite-Guardian-3.3-8B':
             self.model_id = 'ibm-granite/granite-guardian-3.3-8b'
             self.operating_mode="gg_hybrid"
+        elif model_id == 'TBD':
+            self.model_id = 'TBD'
+            self.operating_mode="thinking"
+            self.thinking_end_token=self.tokenizer.convert_tokens_to_ids("</think>")
         else:
             raise ValueError("model_id must be 'Bespoke-MiniCheck-7B'")
 
@@ -374,6 +378,13 @@ class LLMCheck:
             messages = [{"role": "assistant", "content": claim}]
             guardian_config = {"criteria_id": "groundedness"}
             text = self.tokenizer.apply_chat_template(messages, guardian_config = guardian_config, documents=documents, think=True, tokenize=False, add_generation_prompt=True)
+        elif self.operating_mode=="thinking":
+            user_prompt = self.user_prompt.replace("[DOCUMENT]", doc).replace("[CLAIM]", claim)
+            message = [
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": user_prompt},
+            ]
+            text = self.tokenizer.apply_chat_template(message, add_generation_prompt=True, tokenize=False, enable_thinking=True)
         return text
 
     
@@ -397,6 +408,33 @@ class LLMCheck:
         except Exception as e:
             print("Error:", e)
             support_prob = random.random()
+        return support_prob
+    
+    def get_support_prob_thinking(self, response):
+        """probs from vllm inference"""
+        import math
+        support_prob = 0
+
+        try:
+            thinking_token_index = response.outputs[0].token_ids.index(self.thinking_end_token) + 1
+
+            decoded_token = next(iter(response.outputs[0].logprobs[thinking_token_index].values())).decoded_token
+
+            while("\n" in decoded_token and thinking_token_index < len(response.outputs[0].token_ids) - 1):
+                thinking_token_index += 1
+                decoded_token = next(iter(response.outputs[0].logprobs[thinking_token_index].values())).decoded_token
+
+            if thinking_token_index < len(response.outputs[0].token_ids):
+                start_response_index = thinking_token_index
+        except Exception as e:
+            print("Error:", e)
+            support_prob = random.random()
+
+        for token_prob in response.outputs[0].logprobs[start_response_index].values():
+            decoded_token = token_prob.decoded_token
+            if decoded_token.lower() == 'yes': 
+                support_prob += math.exp(token_prob.logprob)
+        
         return support_prob
 
 
@@ -469,6 +507,8 @@ class LLMCheck:
             probs_per_chunk_sentence = [self.get_support_prob(responses[idx]) for idx in range(len(responses))]
         elif self.operating_mode=="gg_hybrid":
             probs_per_chunk_sentence = [self.get_support_prob_hybrid_gg(responses[idx]) for idx in range(len(responses))]
+        elif self.operating_mode=="thinking":
+            probs_per_chunk_sentence = [self.get_support_prob_thinking(responses[idx]) for idx in range(len(responses))]
 
         result_dict = {}
         for index, prob_per_chunk_sentence in zip(doc_claim_indices, probs_per_chunk_sentence):

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -434,15 +434,16 @@ class LLMCheck:
 
         try:
             if self.thinking_end_token in completion.token_ids:
+                max_token_index =  len(completion.token_ids) - 1
                 thinking_token_index = completion.token_ids.index(self.thinking_end_token) + 1
 
                 decoded_token = next(iter(completion.logprobs[thinking_token_index].values())).decoded_token
 
-                while("\n" in decoded_token and thinking_token_index < len(completion.token_ids) - 1):
+                while("\n" in decoded_token and max_token_index):
                     thinking_token_index += 1
                     decoded_token = next(iter(completion.logprobs[thinking_token_index].values())).decoded_token
 
-                if thinking_token_index < len(completion.token_ids):
+                if thinking_token_index <= max_token_index:
                     start_response_index = thinking_token_index
 
             for token_prob in completion.logprobs[start_response_index].values():

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -442,7 +442,11 @@ class LLMCheck:
                     support_prob += math.exp(token_prob.logprob)
         except Exception as e:
             print("Error:", e)
-            support_prob = random.random()
+            
+            for token_prob in response.outputs[0].logprobs[-1].values():
+                decoded_token = token_prob.decoded_token
+                if decoded_token.lower() == 'yes': 
+                    support_prob += math.exp(token_prob.logprob)
         
         return support_prob
 

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -422,6 +422,7 @@ class LLMCheck:
         """probs from vllm inference"""
         import math
         support_prob = 0
+        start_response_index = 0
 
         try:
             thinking_token_index = response.outputs[0].token_ids.index(self.thinking_end_token) + 1

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -300,10 +300,11 @@ class LLMCheck:
             self.model_id = model_id
             self.operating_mode=operating_mode
             self.extra_chat_template_kwargs = extra_chat_template_kwargs
-            self.peft_path = peft_path
 
             if operating_mode == "thinking":
                 self.thinking_end_token=self.tokenizer.convert_tokens_to_ids(think_end_token)
+
+        self.peft_path = peft_path
 
         self.tensor_parallel_size = tensor_parallel_size
         self.max_tokens = max_tokens

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -299,10 +299,6 @@ class LLMCheck:
             self.model_id = model_id
             self.operating_mode=operating_mode
 
-            if operating_mode == "thinking":
-                self.thinking_end_token=self.tokenizer.convert_tokens_to_ids("</think>")
-            #raise ValueError("model_id must be 'Bespoke-MiniCheck-7B'")
-
         self.peft_path = peft_path
 
         self.tensor_parallel_size = tensor_parallel_size
@@ -354,6 +350,9 @@ class LLMCheck:
         if converted_token is not None:
             terminators.append(converted_token)
 
+        if operating_mode == "thinking":
+            self.thinking_end_token=self.tokenizer.convert_tokens_to_ids("</think>")
+        
         self.sampling_params = SamplingParams(
             temperature=0,
             max_tokens=self.max_tokens,

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -288,6 +288,8 @@ class LLMCheck:
         if model_id == 'Bespoke-MiniCheck-7B':
             self.model_id = 'bespokelabs/Bespoke-MiniCheck-7B'
             self.operating_mode="bespoke"
+
+            self.extra_chat_template_kwargs = {}
         elif model_id == 'Granite-Guardian-3.3-8B':
             self.model_id = 'ibm-granite/granite-guardian-3.3-8b'
             self.operating_mode="gg_hybrid"

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -271,7 +271,7 @@ class Inferencer():
 
 class LLMCheck:
 
-    def __init__(self, model_id, operating_mode="bespoke", tensor_parallel_size=1, max_tokens=1, cache_dir=None, enable_prefix_caching=False, max_model_len=None):
+    def __init__(self, model_id, peft_path=None, max_lora_rank=16, operating_mode="bespoke", tensor_parallel_size=1, max_tokens=1, cache_dir=None, enable_prefix_caching=False, max_model_len=None):
         from vllm import LLM, SamplingParams
 
         import logging
@@ -299,9 +299,11 @@ class LLMCheck:
             self.model_id = model_id
             self.operating_mode=operating_mode
 
-            if operating_model == "thinking":
+            if operating_mode == "thinking":
                 self.thinking_end_token=self.tokenizer.convert_tokens_to_ids("</think>")
             #raise ValueError("model_id must be 'Bespoke-MiniCheck-7B'")
+
+        self.peft_path = peft_path
 
         self.tensor_parallel_size = tensor_parallel_size
         self.max_tokens = max_tokens
@@ -338,7 +340,9 @@ class LLMCheck:
             tensor_parallel_size=self.tensor_parallel_size,
             seed=2024,
             max_model_len=self.max_model_len,   # need to be adjusted based on the GPU memory available
-            enable_prefix_caching=self.enable_prefix_caching
+            enable_prefix_caching=self.enable_prefix_caching,
+            max_lora_rank=max_lora_rank,
+            enable_lora=True if peft_path is not None else False
         )
 
         self.tokenizer = self.llm.get_tokenizer()
@@ -507,7 +511,19 @@ class LLMCheck:
             all_prompts.extend(prompts)
             doc_claim_indices.extend([index] * len(prompts))
 
-        responses = self.llm.generate(all_prompts, self.sampling_params) 
+        if self.peft_path is not None:
+            from vllm.lora.request import LoRARequest
+
+            responses = self.llm.generate(
+                all_prompts, 
+                self.sampling_params,
+                lora_request=LoRARequest("lora_adapter", 1, self.peft_path) if self.peft_path else None)
+        else:
+             responses = self.llm.generate(
+                all_prompts, 
+                self.sampling_params)
+
+
         if self.operating_mode=="bespoke":
             probs_per_chunk_sentence = [self.get_support_prob(responses[idx]) for idx in range(len(responses))]
         elif self.operating_mode=="gg_hybrid":

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -271,7 +271,7 @@ class Inferencer():
 
 class LLMCheck:
 
-    def __init__(self, model_id, peft_path=None, max_lora_rank=16, operating_mode="bespoke", tensor_parallel_size=1, max_tokens=1, cache_dir=None, enable_prefix_caching=False, max_model_len=None):
+    def __init__(self, model_id, peft_path=None, max_lora_rank=16, operating_mode="bespoke", think_end_token="</think>", extra_chat_template_kwargs=None, tensor_parallel_size=1, max_tokens=1, cache_dir=None, enable_prefix_caching=False, max_model_len=None):
         from vllm import LLM, SamplingParams
 
         import logging
@@ -291,15 +291,19 @@ class LLMCheck:
         elif model_id == 'Granite-Guardian-3.3-8B':
             self.model_id = 'ibm-granite/granite-guardian-3.3-8b'
             self.operating_mode="gg_hybrid"
-        elif model_id == 'TBD':
-            self.model_id = 'TBD'
-            self.operating_mode="thinking"
-            self.thinking_end_token=self.tokenizer.convert_tokens_to_ids("</think>")
+
+            self.extra_chat_template_kwargs = {
+                'guardian_config': {"criteria_id": "groundedness"},
+                'think': True
+            }
         else:
             self.model_id = model_id
             self.operating_mode=operating_mode
+            self.extra_chat_template_kwargs = extra_chat_template_kwargs
+            self.peft_path = peft_path
 
-        self.peft_path = peft_path
+            if operating_mode == "thinking":
+                self.thinking_end_token=self.tokenizer.convert_tokens_to_ids(think_end_token)
 
         self.tensor_parallel_size = tensor_parallel_size
         self.max_tokens = max_tokens
@@ -338,7 +342,7 @@ class LLMCheck:
             max_model_len=self.max_model_len,   # need to be adjusted based on the GPU memory available
             enable_prefix_caching=self.enable_prefix_caching,
             max_lora_rank=max_lora_rank,
-            enable_lora=True if peft_path is not None else False
+            enable_lora=True if self.peft_path is not None else False
         )
 
         self.tokenizer = self.llm.get_tokenizer()
@@ -349,9 +353,6 @@ class LLMCheck:
         converted_token = self.tokenizer.convert_tokens_to_ids("<|eot_id|>")
         if converted_token is not None:
             terminators.append(converted_token)
-
-        if operating_mode == "thinking":
-            self.thinking_end_token=self.tokenizer.convert_tokens_to_ids("</think>")
         
         self.sampling_params = SamplingParams(
             temperature=0,
@@ -380,19 +381,19 @@ class LLMCheck:
                 {"role": "system", "content": self.system_prompt},
                 {"role": "user", "content": user_prompt},
             ]
-            text = self.tokenizer.apply_chat_template(message, add_generation_prompt=True, tokenize=False)
+            text = self.tokenizer.apply_chat_template(message, add_generation_prompt=True, tokenize=False, **self.extra_chat_template_kwargs)
         elif self.operating_mode=="gg_hybrid":
             documents = [{'doc_id':'0', 'text': doc}]
             messages = [{"role": "assistant", "content": claim}]
-            guardian_config = {"criteria_id": "groundedness"}
-            text = self.tokenizer.apply_chat_template(messages, guardian_config = guardian_config, documents=documents, think=True, tokenize=False, add_generation_prompt=True)
+            text = self.tokenizer.apply_chat_template(messages, documents=documents, add_generation_prompt=True, tokenize=False, **self.extra_chat_template_kwargs)
         elif self.operating_mode=="thinking":
             user_prompt = self.user_prompt.replace("[DOCUMENT]", doc).replace("[CLAIM]", claim)
             message = [
                 {"role": "system", "content": self.system_prompt},
                 {"role": "user", "content": user_prompt},
             ]
-            text = self.tokenizer.apply_chat_template(message, add_generation_prompt=True, tokenize=False, enable_thinking=True)
+            text = self.tokenizer.apply_chat_template(message, add_generation_prompt=True, tokenize=False, **self.extra_chat_template_kwargs)
+
         return text
 
     
@@ -422,32 +423,31 @@ class LLMCheck:
         """probs from vllm inference"""
         import math
         support_prob = 0
-        start_response_index = 0
+        start_response_index = -1
+
+        completion = response.outputs[0]
 
         try:
-            thinking_token_index = response.outputs[0].token_ids.index(self.thinking_end_token) + 1
+            if self.thinking_end_token in completion.token_ids:
+                thinking_token_index = completion.token_ids.index(self.thinking_end_token) + 1
 
-            decoded_token = next(iter(response.outputs[0].logprobs[thinking_token_index].values())).decoded_token
+                decoded_token = next(iter(completion.logprobs[thinking_token_index].values())).decoded_token
 
-            while("\n" in decoded_token and thinking_token_index < len(response.outputs[0].token_ids) - 1):
-                thinking_token_index += 1
-                decoded_token = next(iter(response.outputs[0].logprobs[thinking_token_index].values())).decoded_token
+                while("\n" in decoded_token and thinking_token_index < len(completion.token_ids) - 1):
+                    thinking_token_index += 1
+                    decoded_token = next(iter(completion.logprobs[thinking_token_index].values())).decoded_token
 
-            if thinking_token_index < len(response.outputs[0].token_ids):
-                start_response_index = thinking_token_index
+                if thinking_token_index < len(completion.token_ids):
+                    start_response_index = thinking_token_index
 
-            for token_prob in response.outputs[0].logprobs[start_response_index].values():
+            for token_prob in completion.logprobs[start_response_index].values():
                 decoded_token = token_prob.decoded_token
                 if decoded_token.lower() == 'yes': 
                     support_prob += math.exp(token_prob.logprob)
         except Exception as e:
             print("Error:", e)
+            support_prob = random.random()
             
-            for token_prob in response.outputs[0].logprobs[-1].values():
-                decoded_token = token_prob.decoded_token
-                if decoded_token.lower() == 'yes': 
-                    support_prob += math.exp(token_prob.logprob)
-        
         return support_prob
 
 
@@ -526,7 +526,6 @@ class LLMCheck:
              responses = self.llm.generate(
                 all_prompts, 
                 self.sampling_params)
-
 
         if self.operating_mode=="bespoke":
             probs_per_chunk_sentence = [self.get_support_prob(responses[idx]) for idx in range(len(responses))]

--- a/minicheck/inference.py
+++ b/minicheck/inference.py
@@ -435,14 +435,14 @@ class LLMCheck:
 
             if thinking_token_index < len(response.outputs[0].token_ids):
                 start_response_index = thinking_token_index
+
+            for token_prob in response.outputs[0].logprobs[start_response_index].values():
+                decoded_token = token_prob.decoded_token
+                if decoded_token.lower() == 'yes': 
+                    support_prob += math.exp(token_prob.logprob)
         except Exception as e:
             print("Error:", e)
             support_prob = random.random()
-
-        for token_prob in response.outputs[0].logprobs[start_response_index].values():
-            decoded_token = token_prob.decoded_token
-            if decoded_token.lower() == 'yes': 
-                support_prob += math.exp(token_prob.logprob)
         
         return support_prob
 

--- a/minicheck/minicheck.py
+++ b/minicheck/minicheck.py
@@ -77,6 +77,8 @@ class MiniCheck:
         if not bypass_model_check:
             assert model_name in ['roberta-large', 'deberta-v3-large', 'flan-t5-large', 'Bespoke-MiniCheck-7B', 'Granite-Guardian-3.3-8B'], \
                 "model_name must be one of ['roberta-large', 'deberta-v3-large', 'flan-t5-large', 'Bespoke-MiniCheck-7B', 'Granite-Guardian-3.3-8B']"
+        else:
+            self._bypass_model_check = True
 
         
         if model_name in ['roberta-large', 'deberta-v3-large', 'flan-t5-large']:
@@ -174,4 +176,4 @@ class MiniCheck:
         return pred_label, max_support_prob, used_chunk, support_prob_per_chunk
     
     def _score_llmcheck(self, docs, claims, chunk_size):
-        return self.model.score(docs, claims, chunk_size)
+        return self.model.score(docs, claims, chunk_size, self._bypass_model_check)

--- a/minicheck/minicheck.py
+++ b/minicheck/minicheck.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 class MiniCheck:
-    def __init__(self, model_name='Bespoke-MiniCheck-7B', max_model_len=None, batch_size=16, cache_dir=None, tensor_parallel_size=1, max_tokens=1, enable_prefix_caching=False, bypass_model_check=False) -> None:
+    def __init__(self, model_name='Bespoke-MiniCheck-7B', operating_mode="bespoke", max_model_len=None, batch_size=16, cache_dir=None, tensor_parallel_size=1, max_tokens=1, enable_prefix_caching=False, bypass_model_check=False) -> None:
 
         '''
         Parameters:
@@ -119,6 +119,7 @@ class MiniCheck:
         else:
             self.model = LLMCheck(
                 model_id=model_name,
+                operating_mode=operating_mode,
                 tensor_parallel_size=tensor_parallel_size,
                 max_tokens=max_tokens,
                 cache_dir=cache_dir,

--- a/minicheck/minicheck.py
+++ b/minicheck/minicheck.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 class MiniCheck:
-    def __init__(self, model_name='Bespoke-MiniCheck-7B', operating_mode="bespoke", max_model_len=None, batch_size=16, cache_dir=None, tensor_parallel_size=1, max_tokens=1, enable_prefix_caching=False, bypass_model_check=False) -> None:
+    def __init__(self, model_name='Bespoke-MiniCheck-7B', peft_path=None, max_lora_rank=16, operating_mode="bespoke", max_model_len=None, batch_size=16, cache_dir=None, tensor_parallel_size=1, max_tokens=1, enable_prefix_caching=False, bypass_model_check=False) -> None:
 
         '''
         Parameters:
@@ -19,6 +19,12 @@ class MiniCheck:
             - 'Bespoke-MiniCheck-7B'
             - 'Granite-Guardian-3.3-8B'
             Note: 'Bespoke-MiniCheck-7B' is the most performant fact-checking model in the MiniCheck series.
+
+        peft_path : str optional (default=None)
+            Path to the PEFT adapter
+
+        max_lora_rank : int optional (default=16)
+            Maximum LoRA Adapter Rank to load
         
         max_model_len : int or None, optional (default=None)
             The maximum input length for the model. If None, we use the following default values. 
@@ -119,6 +125,8 @@ class MiniCheck:
         else:
             self.model = LLMCheck(
                 model_id=model_name,
+                peft_path=peft_path,
+                max_lora_rank=max_lora_rank,
                 operating_mode=operating_mode,
                 tensor_parallel_size=tensor_parallel_size,
                 max_tokens=max_tokens,

--- a/minicheck/minicheck.py
+++ b/minicheck/minicheck.py
@@ -32,6 +32,8 @@ class MiniCheck:
                     Default: 32768
                 - 'Granite-Guardian-3.3-8B'
                     Default: 32768
+                - 'TBD'
+                    Default: 11468
             For 'Bespoke-MiniCheck-7B', if you have a GPU with low VRAM and get the following:
                 "ValueError: The model's max seq len (XXXX) is larger than the maximum number of 
                 tokens that can be stored in KV cache (YYYY). Try increasing `gpu_memory_utilization` 
@@ -104,6 +106,15 @@ class MiniCheck:
                 cache_dir=cache_dir,
                 enable_prefix_caching=enable_prefix_caching,
                 max_model_len=max_model_len
+            )
+        elif model_name == 'TBD':
+            self.model = LLMCheck(
+                model_id=model_name,
+                tensor_parallel_size=tensor_parallel_size,
+                max_tokens=max_tokens,
+                cache_dir=cache_dir,
+                enable_prefix_caching=enable_prefix_caching,
+                max_model_len=max_model_len,
             )
         
 

--- a/minicheck/minicheck.py
+++ b/minicheck/minicheck.py
@@ -77,9 +77,6 @@ class MiniCheck:
         if not bypass_model_check:
             assert model_name in ['roberta-large', 'deberta-v3-large', 'flan-t5-large', 'Bespoke-MiniCheck-7B', 'Granite-Guardian-3.3-8B'], \
                 "model_name must be one of ['roberta-large', 'deberta-v3-large', 'flan-t5-large', 'Bespoke-MiniCheck-7B', 'Granite-Guardian-3.3-8B']"
-        else:
-            self._bypass_model_check = True
-
         
         if model_name in ['roberta-large', 'deberta-v3-large', 'flan-t5-large']:
             self.model = Inferencer(
@@ -176,4 +173,4 @@ class MiniCheck:
         return pred_label, max_support_prob, used_chunk, support_prob_per_chunk
     
     def _score_llmcheck(self, docs, claims, chunk_size):
-        return self.model.score(docs, claims, chunk_size, self._bypass_model_check)
+        return self.model.score(docs, claims, chunk_size)

--- a/minicheck/minicheck.py
+++ b/minicheck/minicheck.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 class MiniCheck:
-    def __init__(self, model_name='Bespoke-MiniCheck-7B', max_model_len=None, batch_size=16, cache_dir=None, tensor_parallel_size=1, max_tokens=1, enable_prefix_caching=False) -> None:
+    def __init__(self, model_name='Bespoke-MiniCheck-7B', max_model_len=None, batch_size=16, cache_dir=None, tensor_parallel_size=1, max_tokens=1, enable_prefix_caching=False, bypass_model_check=False) -> None:
 
         '''
         Parameters:
@@ -74,8 +74,9 @@ class MiniCheck:
         future grounded fact-checking with much higher throughput and much lower latency.
         '''
 
-        assert model_name in ['roberta-large', 'deberta-v3-large', 'flan-t5-large', 'Bespoke-MiniCheck-7B', 'Granite-Guardian-3.3-8B'], \
-            "model_name must be one of ['roberta-large', 'deberta-v3-large', 'flan-t5-large', 'Bespoke-MiniCheck-7B', 'Granite-Guardian-3.3-8B']"
+        if not bypass_model_check:
+            assert model_name in ['roberta-large', 'deberta-v3-large', 'flan-t5-large', 'Bespoke-MiniCheck-7B', 'Granite-Guardian-3.3-8B'], \
+                "model_name must be one of ['roberta-large', 'deberta-v3-large', 'flan-t5-large', 'Bespoke-MiniCheck-7B', 'Granite-Guardian-3.3-8B']"
 
         
         if model_name in ['roberta-large', 'deberta-v3-large', 'flan-t5-large']:
@@ -108,6 +109,15 @@ class MiniCheck:
                 max_model_len=max_model_len
             )
         elif model_name == 'TBD':
+            self.model = LLMCheck(
+                model_id=model_name,
+                tensor_parallel_size=tensor_parallel_size,
+                max_tokens=max_tokens,
+                cache_dir=cache_dir,
+                enable_prefix_caching=enable_prefix_caching,
+                max_model_len=max_model_len,
+            )
+        else:
             self.model = LLMCheck(
                 model_id=model_name,
                 tensor_parallel_size=tensor_parallel_size,

--- a/minicheck/minicheck.py
+++ b/minicheck/minicheck.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 class MiniCheck:
-    def __init__(self, model_name='Bespoke-MiniCheck-7B', peft_path=None, max_lora_rank=16, operating_mode="bespoke", max_model_len=None, batch_size=16, cache_dir=None, tensor_parallel_size=1, max_tokens=1, enable_prefix_caching=False, bypass_model_check=False) -> None:
+    def __init__(self, model_name='Bespoke-MiniCheck-7B', peft_path=None, max_lora_rank=16, operating_mode="bespoke", think_end_token=None, extra_chat_template_kwargs=None, max_model_len=None, batch_size=16, cache_dir=None, tensor_parallel_size=1, max_tokens=1, enable_prefix_caching=False, bypass_model_check=False) -> None:
 
         '''
         Parameters:
@@ -20,11 +20,32 @@ class MiniCheck:
             - 'Granite-Guardian-3.3-8B'
             Note: 'Bespoke-MiniCheck-7B' is the most performant fact-checking model in the MiniCheck series.
 
-        peft_path : str optional (default=None)
-            Path to the PEFT adapter
+        peft_path : str, optional (default=None)
+            Path to the LLM PEFT adapter
+                - 'Bespoke-MiniCheck-7B'
+                    peft_path: None
+                - 'Granite-Guardian-3.3-8B'
+                    peft_path: None
 
-        max_lora_rank : int optional (default=16)
+        max_lora_rank : int, optional (default=16)
             Maximum LoRA Adapter Rank to load
+
+        operating_mode : str, optional (default='bespoke')
+            LLM model support probability operating mode
+            Preset models use their corresponding operating mode, i.e:
+                - 'Bespoke-MiniCheck-7B'
+                    Operating Mode: 'bespoke'
+                - 'Granite-Guardian-3.3-8B'
+                    Operating Mode: 'gg_hybrid'
+            Extra operating mode:
+                - 'thinking' uses the first logprobs after the thinking delimiter as support probability
+
+        think_end_token : str, optional (default=None)
+            Token used to represent the end of the thinking traces of LLM models
+
+        extra_chat_template_kwargs : dict, optional (default=None)
+            Extra kwargs to forward to the chat template
+            Preset models use their corresponding chat template kwargs
         
         max_model_len : int or None, optional (default=None)
             The maximum input length for the model. If None, we use the following default values. 
@@ -38,8 +59,6 @@ class MiniCheck:
                     Default: 32768
                 - 'Granite-Guardian-3.3-8B'
                     Default: 32768
-                - 'TBD'
-                    Default: 11468
             For 'Bespoke-MiniCheck-7B', if you have a GPU with low VRAM and get the following:
                 "ValueError: The model's max seq len (XXXX) is larger than the maximum number of 
                 tokens that can be stored in KV cache (YYYY). Try increasing `gpu_memory_utilization` 
@@ -65,6 +84,9 @@ class MiniCheck:
             Whether to enable prefix caching for 'Bespoke-MiniCheck-7B'. This can improve performance
             when using the same document chunk to fact-check different claims.
 
+        bypass_model_check: bool, optional (default=False)
+            Allows to bypass the model check to run the benchmark on different models with various configuration
+
         Note:
         (1) MiniCheck-Flan-T5-Large (770M) is the best fack-checking model with size < 1B and reaches GPT-4 performance.
         (2) Bespoke-MiniCheck-7B is the most performant fact-checking model in the MiniCheck series AND
@@ -85,6 +107,9 @@ class MiniCheck:
                 "model_name must be one of ['roberta-large', 'deberta-v3-large', 'flan-t5-large', 'Bespoke-MiniCheck-7B', 'Granite-Guardian-3.3-8B']"
         
         if model_name in ['roberta-large', 'deberta-v3-large', 'flan-t5-large']:
+            if operating_mode != 'operating_mode' or extra_chat_template_kwargs is not None or peft_path is not None or think_end_token is not None:
+                print(f"Forcing default preset configuration for model {model_name}")
+
             self.model = Inferencer(
                 model_name=model_name, 
                 batch_size=batch_size, 
@@ -92,6 +117,9 @@ class MiniCheck:
                 cache_dir=cache_dir
             )
         elif model_name == 'Bespoke-MiniCheck-7B':
+            if operating_mode != 'bespoke' or extra_chat_template_kwargs is not None or peft_path is not None or think_end_token is not None:
+                print("Forcing default preset configuration for model Bespoke-MiniCheck-7B")
+
             self.model = LLMCheck(
                 model_id=model_name,
                 tensor_parallel_size=tensor_parallel_size,
@@ -101,6 +129,9 @@ class MiniCheck:
                 max_model_len=max_model_len
             )
         elif model_name == 'Granite-Guardian-3.3-8B':
+            if operating_mode != 'gg_hybrid' or extra_chat_template_kwargs is not None or peft_path is not None or think_end_token is not None:
+                print("Forcing default preset configuration for model Granite Guardian 3.3")
+
             if not max_tokens or max_tokens<2048:
                 print("For Granite Guardian 3.3 - fixing the max_tokens to be 2048")
                 max_tokens=2048
@@ -113,26 +144,22 @@ class MiniCheck:
                 enable_prefix_caching=enable_prefix_caching,
                 max_model_len=max_model_len
             )
-        elif model_name == 'TBD':
-            self.model = LLMCheck(
-                model_id=model_name,
-                tensor_parallel_size=tensor_parallel_size,
-                max_tokens=max_tokens,
-                cache_dir=cache_dir,
-                enable_prefix_caching=enable_prefix_caching,
-                max_model_len=max_model_len,
-            )
         else:
+            if operating_mode == "thinking":
+                assert think_end_token is not None, "'thinking' operating mode requires to specify a 'think_end_token'"
+
             self.model = LLMCheck(
                 model_id=model_name,
                 peft_path=peft_path,
                 max_lora_rank=max_lora_rank,
                 operating_mode=operating_mode,
+                think_end_token=think_end_token,
+                extra_chat_template_kwargs=extra_chat_template_kwargs,
                 tensor_parallel_size=tensor_parallel_size,
                 max_tokens=max_tokens,
                 cache_dir=cache_dir,
                 enable_prefix_caching=enable_prefix_caching,
-                max_model_len=max_model_len,
+                max_model_len=max_model_len
             )
         
 


### PR DESCRIPTION
Pull Request to add support to run other LLMs through the library and evaluate them.

- Peft Adapters (with configurable max lora rank)
- Passing Chat Template Kwargs 
- Benchmarking other LLMs
- Additional Evaluation mode (and extensible to adding more of them)
  - Naive Thinking mode (first token after thinking)
  
  All while preserving current model's preset configuration